### PR TITLE
Remove embeddings from async task requests to reduce payload size

### DIFF
--- a/frontend/src/components/MVVAnalysis/BusinessInnovationLab.tsx
+++ b/frontend/src/components/MVVAnalysis/BusinessInnovationLab.tsx
@@ -526,11 +526,14 @@ export const BusinessInnovationLab: React.FC = () => {
       console.log(`📊 Current verificationResults:`, verificationResults);
       
       // 非同期タスクリクエストを作成
+      // embeddingsデータを削除してリクエストサイズを軽量化
+      const { embeddings, ...companyDataWithoutEmbeddings } = selectedCompany;
+      
       const taskRequest: AsyncTaskCreateRequest = {
         type: 'verify-business-idea',
         inputData: {
           originalIdea: idea,
-          companyData: selectedCompany,
+          companyData: companyDataWithoutEmbeddings,
           verificationLevel
         },
         config: {


### PR DESCRIPTION
## Problem

Business Innovation Lab verification was failing with 500 Internal Server Error when starting async verification tasks. The error occurred when calling the `start-async-task` endpoint.

## Root Cause

The `selectedCompany` object contains `embeddings` field with large numerical arrays that significantly increase request payload size. These embeddings are not needed for business idea verification and were causing the request to exceed size limits.

## Solution

Remove the `embeddings` field from `companyData` before creating async task requests in the Business Innovation Lab verification flow.

## Changes

- Modified `handleVerifyIdea` function in BusinessInnovationLab.tsx
- Added destructuring to remove `embeddings` from `selectedCompany` before sending to async task
- Maintains all other necessary company data for verification process

## Benefits

- Significantly reduces request payload size
- Resolves 500 Internal Server Error when starting async verification
- Improves performance by sending only necessary data
- No impact on verification functionality

## Testing

- ✅ Frontend builds successfully
- ✅ TypeScript compilation passes
- Ready for production deployment and testing